### PR TITLE
Fix parsing of preferred version ranges.

### DIFF
--- a/src/Distribution/Hackage/DB/Parsed.hs
+++ b/src/Distribution/Hackage/DB/Parsed.hs
@@ -55,7 +55,14 @@ parsePackageData pn (U.PackageData pv vs') =
       Map.filterWithKey (\v _ -> v `withinRange` vr) vs'
   where
     vr | BSS.null pv = anyVersion
-       | otherwise = parseText "preferred version range" (toString pv)
+       | otherwise = parseText "preferred version range"
+                     (toString $
+                      -- pv is something like: "containers <0.5.8.1 || >0.5.8.1".
+                      -- The first word should match pn and should be removed to
+                      -- allow parseText to parse the VersionRange; this is
+                      -- simply done by dropping the first word (non-space chars)
+                      BSS.dropWhile (/= toEnum 32) $  -- 32 = ASCII space
+                      pv)
 
 parseVersionData :: PackageName -> Version -> U.VersionData -> VersionData
 parseVersionData pn v (U.VersionData cf m) =

--- a/src/Distribution/Hackage/DB/Parsed.hs
+++ b/src/Distribution/Hackage/DB/Parsed.hs
@@ -61,7 +61,7 @@ parsePackageData pn (U.PackageData pv vs') =
                       -- The first word should match pn and should be removed to
                       -- allow parseText to parse the VersionRange; this is
                       -- simply done by dropping the first word (non-space chars)
-                      BSS.dropWhile (/= toEnum 32) $  -- 32 = ASCII space
+                      BSS.dropWhile (/= toEnum 32)   -- 32 = ASCII space
                       pv)
 
 parseVersionData :: PackageName -> Version -> U.VersionData -> VersionData


### PR DESCRIPTION
The preferred version range starts with the name of the current package; this name must be removed to allow a valid parse as a `VersionRange`.

Prior to this change:
>    $ cabal run show-package-versions containers
>    show-package-versions: HackageDBPackageName (PackageName "containers") (InvalidRepresentationOfType "preferred version range" "containers <0.5.8.1 || >0.5.8.1 && <0.5.9.1 || >0.5.9.1")

After this change:
>    $ cabal run show-package-versions containers
>    containers: 0.1.0.0 0.1.0.1 0.2.0.0 0.2.0.1 0.3.0.0 0.4.0.0 0.4.1.0 0.4.2.0 0.4.2.1 0.5.0.0 0.5.1.0 0.5.2.0 0.5.2.1 0.5.3.0 0.5.3.1 0.5.4.0 0.5.5.0 0.5.5.1 0.5.6.0 0.5.6.1 0.5.6.2 0.5.6.3 0.5.7.0 0.5.7.1 0.5.8.2 0.5.9.2 0.5.10.1 0.5.10.2 0.5.11.0 0.6.0.1 0.6.1.1 0.6.2.1 0.6.3.1 0.6.4.1