### PR TITLE
fix(parsePackageData): parse version ranges w/ `PackageVersionConstraint`

### DIFF
--- a/src/Distribution/Hackage/DB/Parsed.hs
+++ b/src/Distribution/Hackage/DB/Parsed.hs
@@ -27,6 +27,7 @@ import Distribution.Package
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Parsec
 import Distribution.Text
+import Distribution.Types.PackageVersionConstraint
 import Distribution.Version
 import GHC.Generics ( Generic )
 
@@ -54,8 +55,9 @@ parsePackageData pn (U.PackageData pv vs') =
     Map.mapWithKey (parseVersionData pn) $
       Map.filterWithKey (\v _ -> v `withinRange` vr) vs'
   where
-    vr | BSS.null pv = anyVersion
-       | otherwise = parseText "preferred version range" (toString pv)
+    PackageVersionConstraint _ vr
+      | BSS.null pv = PackageVersionConstraint pn anyVersion
+      | otherwise = parseText "preferred version range" (toString pv)
 
 parseVersionData :: PackageName -> Version -> U.VersionData -> VersionData
 parseVersionData pn v (U.VersionData cf m) =


### PR DESCRIPTION
Previously we used `Dependency` for this which became impossible with
Cabal 3.4.0.0 since the third field became a `NonEmptySet` in that
version whereas in our use case it would always be empty.

We can't however parse the version range in an isolated fashion, since
that leads to problems like https://github.com/NixOS/cabal2nix/issues/501
The solution is to use `PackageVersionConstraint` which seems to be the
intended type to use instead of `Dependency` for these kinds of
applications.

A new release with this fix would be useful.